### PR TITLE
Renderflex overflow in OTP verification screen fixed.

### DIFF
--- a/lib/sections/shared/otp_verification.dart
+++ b/lib/sections/shared/otp_verification.dart
@@ -17,99 +17,104 @@ class _OtpVerificationScreenState extends State<OtpVerificationScreen> {
   Widget build(BuildContext context) {
     return Scaffold(
       resizeToAvoidBottomInset: true,
-      body: SafeArea(
-        child: Padding(
-          padding: EdgeInsets.symmetric(
-            horizontal: Distance_Unit * 4,
-            vertical: Distance_Unit * 4,
-          ),
-          child: Column(
-            mainAxisAlignment: MainAxisAlignment.center,
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: [
-              RoundBackButton(
-                backgroundColor: Color(0xFF6F69AC),
-                arrowIconColor: Colors.white,
-              ),
-              SizedBox(
-                height: Distance_Unit * 10,
-              ),
-              Center(
-                child: Container(
-                  child: SvgPicture.asset(
-                    "assets/svg/otp_mobile.svg",
-                    height: 150,
-                    width: 100,
-                  ),
-                ),
-              ),
-              SizedBox(
-                height: Distance_Unit * 15,
-              ),
-              Column(
+      body: SingleChildScrollView(
+        child: SafeArea(
+          child: Padding(
+            padding: EdgeInsets.symmetric(
+              horizontal: Distance_Unit * 4,
+              vertical: Distance_Unit * 4,
+            ),
+            child: Container(
+              height: Distance_Unit * 173,
+              child: Column(
+                mainAxisAlignment: MainAxisAlignment.center,
+                crossAxisAlignment: CrossAxisAlignment.start,
                 children: [
-                  Text(
-                    "Verification Code",
-                    style: TextStyle(
-                      fontSize: 25,
-                      fontWeight: FontWeight.w600,
+                  RoundBackButton(
+                    backgroundColor: Color(0xFF6F69AC),
+                    arrowIconColor: Colors.white,
+                  ),
+                  SizedBox(
+                    height: Distance_Unit * 10,
+                  ),
+                  Center(
+                    child: Container(
+                      child: SvgPicture.asset(
+                        "assets/svg/otp_mobile.svg",
+                        height: 150,
+                        width: 100,
+                      ),
                     ),
                   ),
                   SizedBox(
-                    height: Distance_Unit * 5,
+                    height: Distance_Unit * 15,
                   ),
-                  Text(
-                    "We have sent the verification code to\nYour Email Id",
-                    textAlign: TextAlign.center,
-                    style: TextStyle(),
-                  ),
-                  SizedBox(
-                    height: Distance_Unit * 5,
-                  ),
-                  Row(
-                    mainAxisAlignment: MainAxisAlignment.center,
+                  Column(
                     children: [
                       Text(
-                        "ashishchaubey866@gmail.com",
+                        "Verification Code",
                         style: TextStyle(
-                          fontWeight: FontWeight.bold,
+                          fontSize: 25,
+                          fontWeight: FontWeight.w600,
                         ),
                       ),
                       SizedBox(
-                        width: Distance_Unit * 2,
+                        height: Distance_Unit * 5,
                       ),
-                      Container(
-                        height: 20,
-                        width: 20,
-                        decoration: BoxDecoration(
-                          borderRadius: BorderRadius.circular(16),
-                          color: Color(0xFFFD6F96),
-                        ),
-                        child: Icon(
-                          Icons.edit,
-                          color: Colors.white,
-                          size: 12,
-                        ),
+                      Text(
+                        "We have sent the verification code to\nYour Email Id",
+                        textAlign: TextAlign.center,
+                        style: TextStyle(),
+                      ),
+                      SizedBox(
+                        height: Distance_Unit * 5,
+                      ),
+                      Row(
+                        mainAxisAlignment: MainAxisAlignment.center,
+                        children: [
+                          Text(
+                            "ashishchaubey866@gmail.com",
+                            style: TextStyle(
+                              fontWeight: FontWeight.bold,
+                            ),
+                          ),
+                          SizedBox(
+                            width: Distance_Unit * 2,
+                          ),
+                          Container(
+                            height: 20,
+                            width: 20,
+                            decoration: BoxDecoration(
+                              borderRadius: BorderRadius.circular(16),
+                              color: Color(0xFFFD6F96),
+                            ),
+                            child: Icon(
+                              Icons.edit,
+                              color: Colors.white,
+                              size: 12,
+                            ),
+                          ),
+                        ],
+                      ),
+                      SizedBox(
+                        height: Distance_Unit * 5,
+                      ),
+                      GenericTextField(
+                        labelText: "OTP",
+                        prefixIconName: Icons.mobile_friendly,
+                        borderColor: Color(0xFFFD6F96),
                       ),
                     ],
                   ),
-                  SizedBox(
-                    height: Distance_Unit * 5,
-                  ),
-                  GenericTextField(
-                    labelText: "OTP",
-                    prefixIconName: Icons.mobile_friendly,
-                    borderColor: Color(0xFFFD6F96),
+                  Spacer(),
+                  GenericButtons(
+                    title: "Submit",
+                    backgroundColor: Color(0xFF6F69AC),
+                    textColor: Colors.white,
                   ),
                 ],
               ),
-              Spacer(),
-              GenericButtons(
-                title: "Submit",
-                backgroundColor: Color(0xFF6F69AC),
-                textColor: Colors.white,
-              ),
-            ],
+            ),
           ),
         ),
       ),


### PR DESCRIPTION
#20 Converted the screen into scrollable and added bounds to column to avoid overflows.
![Screenshot_1633947242](https://user-images.githubusercontent.com/81760629/136774275-6c5faca7-d8f3-408f-b7a0-8d83e3218243.png)
![Screenshot_1633947246](https://user-images.githubusercontent.com/81760629/136774282-66627254-5dda-4adb-b1f0-1732ef575681.png)
