### PR TITLE
Back button in otp-screen hiding fixed

### DIFF
--- a/lib/sections/shared/otp_verification.dart
+++ b/lib/sections/shared/otp_verification.dart
@@ -17,6 +17,17 @@ class _OtpVerificationScreenState extends State<OtpVerificationScreen> {
   Widget build(BuildContext context) {
     return Scaffold(
       resizeToAvoidBottomInset: true,
+      appBar: AppBar(
+        backgroundColor: Colors.white,
+        elevation: 0,
+        leading: Padding(
+          padding: EdgeInsets.all(5),
+          child: RoundBackButton(
+            backgroundColor: Color(0xFF6F69AC),
+            arrowIconColor: Colors.white,
+          ),
+        ),
+      ),
       body: SingleChildScrollView(
         child: SafeArea(
           child: Padding(
@@ -30,10 +41,6 @@ class _OtpVerificationScreenState extends State<OtpVerificationScreen> {
                 mainAxisAlignment: MainAxisAlignment.center,
                 crossAxisAlignment: CrossAxisAlignment.start,
                 children: [
-                  RoundBackButton(
-                    backgroundColor: Color(0xFF6F69AC),
-                    arrowIconColor: Colors.white,
-                  ),
                   SizedBox(
                     height: Distance_Unit * 10,
                   ),


### PR DESCRIPTION
#28 Added app-bar with white color. Safe area widget would take up the scrolling screen up as the button was in the body of scaffold. Let me know it you want any edits.
![Screenshot_1634042136](https://user-images.githubusercontent.com/81760629/136957847-f1700e22-9e76-4c02-9e88-563064d00561.png)
